### PR TITLE
Add option to limit connections to localhost.

### DIFF
--- a/app/src/main/java/com/clusterrr/usbserialtelnetserver/MainActivity.java
+++ b/app/src/main/java/com/clusterrr/usbserialtelnetserver/MainActivity.java
@@ -35,6 +35,7 @@ import com.hoho.android.usbserial.driver.UsbSerialProber;
 import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener, UsbSerialTelnetService.IOnStartStopListener, AdapterView.OnItemSelectedListener {
+    final static String SETTING_LOCAL_ONLY = "local_only";
     final static String SETTING_TCP_PORT = "tcp_port";
     final static String SETTING_BAUD_RATE = "baud_rate";
     final static String SETTING_DATA_BITS = "data_bits";
@@ -53,6 +54,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private boolean mNeedClose = false;
     private Button mStartButton;
     private Button mStopButton;
+    private Switch mLocalOnly;
     private EditText mTcpPort;
     private EditText mBaudRate;
     private Spinner mDataBits;
@@ -75,6 +77,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         mStartButton = findViewById(R.id.buttonStart);
         mStopButton = findViewById(R.id.buttonStop);
+        mLocalOnly = findViewById(R.id.switchLocalOnly);
         mTcpPort = findViewById(R.id.editTextTcpPort);
         mBaudRate = findViewById(R.id.editTextNumberBaudRate);
         mDataBits = findViewById(R.id.spinnerDataBits);
@@ -176,6 +179,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         Intent serviceIntent = new Intent(this, UsbSerialTelnetService.class);
         SharedPreferences prefs = getSharedPreferences(getString(R.string.app_name), Context.MODE_PRIVATE);
+        serviceIntent.putExtra(UsbSerialTelnetService.KEY_LOCAL_ONLY, prefs.getBoolean(SETTING_LOCAL_ONLY, false));
         serviceIntent.putExtra(UsbSerialTelnetService.KEY_TCP_PORT, prefs.getInt(SETTING_TCP_PORT, 2323));
         serviceIntent.putExtra(UsbSerialTelnetService.KEY_BAUD_RATE, prefs.getInt(SETTING_BAUD_RATE, 115200));
         serviceIntent.putExtra(UsbSerialTelnetService.KEY_DATA_BITS, prefs.getInt(SETTING_DATA_BITS, 3) + 5);
@@ -262,6 +266,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             baudRate = 115200;
         }
         prefs.edit()
+                .putBoolean(SETTING_LOCAL_ONLY, mLocalOnly.isChecked())
                 .putInt(SETTING_TCP_PORT, tcpPort)
                 .putInt(SETTING_BAUD_RATE, baudRate)
                 .putInt(SETTING_DATA_BITS, mDataBits.getSelectedItemPosition())
@@ -277,6 +282,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         boolean started = isStarted();
         mStartButton.setEnabled(!started);
         mStopButton.setEnabled(started);
+        mLocalOnly.setEnabled(!started);
         mTcpPort.setEnabled(!started);
         mBaudRate.setEnabled(!started);
         mDataBits.setEnabled(!started);
@@ -284,6 +290,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         mParity.setEnabled(!started);
         mNoLocalEcho.setEnabled(!started);
         mRemoveLF.setEnabled(!started);
+        mLocalOnly.setChecked(prefs.getBoolean(SETTING_LOCAL_ONLY, false));
         mTcpPort.setText(String.valueOf(prefs.getInt(SETTING_TCP_PORT, 2323)));
         mBaudRate.setText(String.valueOf(prefs.getInt(SETTING_BAUD_RATE, 115200)));
         mDataBits.setSelection(prefs.getInt(SETTING_DATA_BITS, 3));
@@ -293,7 +300,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         mRemoveLF.setChecked(prefs.getBoolean(SETTING_REMOVE_LF, true));
         mAutostart.setSelection(prefs.getInt(SETTING_AUTOSTART, AUTOSTART_DISABLED));
         if (started)
-            mStatus.setText(getString(R.string.started_please_connect) + " telnet://" + UsbSerialTelnetService.getIPAddress() + ":"+ mTcpPort.getText());
+            mStatus.setText(getString(R.string.started_please_connect) + " telnet://" + (prefs.getBoolean(SETTING_LOCAL_ONLY, false) ? "127.0.0.1" : UsbSerialTelnetService.getIPAddress()) + ":"+ mTcpPort.getText());
         else
             mStatus.setText(R.string.not_started);
     }

--- a/app/src/main/java/com/clusterrr/usbserialtelnetserver/UsbSerialTelnetService.java
+++ b/app/src/main/java/com/clusterrr/usbserialtelnetserver/UsbSerialTelnetService.java
@@ -35,6 +35,7 @@ import java.util.List;
 public class UsbSerialTelnetService extends Service {
     final static String TAG = "UsbSerialTelnet";
     final static String ACTION_NEED_TO_START = "need_to_start";
+    final static String KEY_LOCAL_ONLY = "local_only";
     final static String KEY_TCP_PORT = "tcp_port";
     final static String KEY_BAUD_RATE = "baud_rate";
     final static String KEY_DATA_BITS = "data_bits";
@@ -120,7 +121,9 @@ public class UsbSerialTelnetService extends Service {
                             intent.getIntExtra(KEY_DATA_BITS, 8),
                             intent.getIntExtra(KEY_STOP_BITS, UsbSerialPort.STOPBITS_1),
                             intent.getIntExtra(KEY_PARITY, UsbSerialPort.PARITY_NONE));
-                    ServerSocket serverSocket = new ServerSocket(intent.getIntExtra(KEY_TCP_PORT,2323));
+                    ServerSocket serverSocket = intent.getBooleanExtra(KEY_LOCAL_ONLY, false) ?
+                            new ServerSocket(intent.getIntExtra(KEY_TCP_PORT, 2323), -1, InetAddress.getByAddress(new byte[]{127, 0, 0, 1})) : // Explicitly use IPv4, as will default to IPv6 otherwise.
+                            new ServerSocket(intent.getIntExtra(KEY_TCP_PORT, 2323));
                     mUsbSerialThread = new UsbSerialThread(this, serialPort);
                     mTcpServerThread = new TcpServerThread(this, serverSocket);
                     mTcpServerThread.setNoLocalEcho(intent.getBooleanExtra(KEY_NO_LOCAL_ECHO, true));

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -61,6 +61,26 @@
             android:layout_gravity="center_horizontal">
 
             <TextView
+                android:id="@+id/textLocalOnly"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="24dp"
+                android:text="@string/local_only"
+                app:layout_constraintBottom_toBottomOf="@+id/switchLocalOnly"
+                app:layout_constraintEnd_toStartOf="@+id/switchLocalOnly"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/switchLocalOnly" />
+
+            <Switch
+                android:id="@+id/switchLocalOnly"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:layout_marginEnd="24dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/textLocalOnly"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
                 android:id="@+id/textViewTcpPort"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -81,7 +101,7 @@
                 android:maxLength="5"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/textViewTcpPort"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toBottomOf="@+id/switchLocalOnly" />
 
             <TextView
                 android:id="@+id/textViewBaudRate"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="no_local_echo">Forced local echo off</string>
     <string name="remove_lf">Convert client\'s CR-LF to CR</string>
     <string name="autostart_on_device_connect">Autostart on device attach</string>
+    <string name="local_only">Local Connections Only</string>
     <string-array name="data_bits">
         <item>5</item>
         <item>6</item>


### PR DESCRIPTION
Due to the insecure nature of Telnet, exposing the server to the wireless network the device is on may pose a security risk.

Added setting to limit ServerSocket's bind to the loopback address, preventing other hosts on the network from connecting.